### PR TITLE
Obey KRB5CCNAME env

### DIFF
--- a/pam_krb5_ccache.spec
+++ b/pam_krb5_ccache.spec
@@ -1,5 +1,5 @@
 Name:           pam_krb5_ccache
-Version:        0.0.2
+Version:        0.1.0
 Release:        1%{?dist}
 Summary:        PAM module for ksu style Kerberos authentication in sudo.
 


### PR DESCRIPTION
Due to upstream changes, setuid programs by default skip kerberos env variables. For this module, we need access to the KRB5CCNAME.

for context : 'KRB5_ENV_CCNAME' is a constant that defines name of environment variable to set credential constant.